### PR TITLE
Bump Android build tools version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,8 +11,8 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
This PR bumps the Android SDK tools version to allow to use this package with other packages that are targeting an higher version of the Android SDK tools.