### PR TITLE
Fixes warning "module requires main queue setup"

### DIFF
--- a/RNI18n/RNI18n.m
+++ b/RNI18n/RNI18n.m
@@ -15,6 +15,10 @@
 @implementation RNI18n
 RCT_EXPORT_MODULE();
 
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
 -(NSString*) getCurrentLocale{
     NSString *localeString=[[NSLocale preferredLanguages] objectAtIndex:0];
     return localeString;


### PR DESCRIPTION
Fixes warning:
Module RNI18n requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup`